### PR TITLE
Simplify chat UI

### DIFF
--- a/client.py
+++ b/client.py
@@ -31,6 +31,7 @@ class ChatClient:
 
 if __name__=="__main__":
     import ui, sys
+
     h,p = sys.argv[1], int(sys.argv[2])
     nick = input("Name: ")
     ChatClient(h,p,nick, ui.ChatUI()).start()

--- a/run
+++ b/run
@@ -7,14 +7,14 @@ if [[ $mode == "server" ]]; then
   port=${2:-6000}
   # билдим и запускаем контейнер
   docker build -t chat-server .
-  docker run --rm -p ${port}:${port} chat-server ${port}
+  docker run --rm -p "${port}":"${port}" chat-server "${port}"
 elif [[ $mode == "client" ]]; then
   if [[ $# -ne 3 ]]; then
-    echo "Usage: $0 client SERVER_IP PORT1"
+    echo "Usage: $0 client SERVER_IP PORT"
     exit 1
   fi
   ip=$2; port=$3
-  python3 client.py $ip $port
+  python3 client.py "$ip" "$port"
 else
   echo "Usage: $0 {server|client}"
   exit 1

--- a/ui.py
+++ b/ui.py
@@ -1,59 +1,26 @@
-import curses
 from protocol import Message
 
 class ChatUI:
     def __init__(self):
-        self.stdscr = None
-        self.lines = []
-        self.status = ""
+        self.running = True
 
     def handle_server(self, msg):
-        if msg.type in ("info", "message"):
-            if msg.type == "info":
-                text = msg.payload.get("text", "")
-            else:
-                text = f"[{msg.payload.get('nick', '')}] {msg.payload.get('text', '')}"
-            self.lines.append(text)
-            self.redraw()
+        if msg.type == "info":
+            print(msg.payload.get("text", ""))
+        elif msg.type == "message":
+            nick = msg.payload.get("nick", "")
+            text = msg.payload.get("text", "")
+            print(f"[{nick}] {text}")
         elif msg.type == "users":
-            self.status = "Users: " + ", ".join(msg.payload.get("list", []))
-            self.redraw()
+            lst = msg.payload.get("list", [])
+            print("Users: " + ", ".join(lst))
 
     def run(self, client):
-        curses.wrapper(self._curses_loop, client)
-
-    def _curses_loop(self, stdscr, client):
-        self.stdscr = stdscr
-        curses.curs_set(1)
-        h, w = stdscr.getmaxyx()
-        win_msgs = curses.newwin(h-2, w, 0, 0)
-        win_status = curses.newwin(1, w, h-2, 0)
-        win_input = curses.newwin(1, w-1, h-1, 0)
-
-        while True:
-            # render messages
-            win_msgs.clear()
-            win_msgs.box()
-            start = max(0, len(self.lines) - (h-2))
-            for idx, line in enumerate(self.lines[start:]):
-                win_msgs.addstr(idx+1, 1, line[:w-2])
-            win_msgs.refresh()
-
-            # render status bar
-            win_status.clear()
-            win_status.addstr(0, 0, self.status[:w-1])
-            win_status.chgat(0, 0, curses.A_REVERSE)
-            win_status.refresh()
-
-            # input
-            win_input.clear()
-            win_input.addstr(0, 0, "> ")
-            win_input.refresh()
+        while self.running:
             try:
-                s = win_input.getstr().decode()
-            except Exception:
+                s = input("> ")
+            except EOFError:
                 break
-
             if s == "!quit":
                 client.send(Message("quit"))
                 break
@@ -61,9 +28,7 @@ class ChatUI:
                 client.send(Message("users"))
             else:
                 client.send(Message("message", text=s))
-
         client.sock.close()
 
-    def redraw(self):
-        # placeholder: will refresh UI on next loop iteration
-        pass
+    def stop(self):
+        self.running = False


### PR DESCRIPTION
## Summary
- use a single simple UI based on standard input
- drop the curses interface and related CLI flags
- adjust helper script

## Testing
- `python3 -m py_compile client.py server.py ui.py protocol.py`
- `shellcheck run`


------
https://chatgpt.com/codex/tasks/task_e_685037724068832c81f25232914f5dac